### PR TITLE
Revert "Mark work as JSON serializable"

### DIFF
--- a/src/Work.php
+++ b/src/Work.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Mammatus\Queue\Contracts;
 
-interface Work extends \JsonSerializable
+interface Work
 {
 }


### PR DESCRIPTION
Reverts MammatusPHP/queue-contracts#6

There is no need to address this here, as the queue uses a hydrator who can do both ways